### PR TITLE
feat: Implementar renovação de tokens com Refresh Token (#3)

### DIFF
--- a/backend/src/main/java/br/com/glprevenda/security/dto/RefreshTokenRequest.java
+++ b/backend/src/main/java/br/com/glprevenda/security/dto/RefreshTokenRequest.java
@@ -1,0 +1,24 @@
+package br.com.glprevenda. security.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO para requisição de renovação de token JWT
+ * 
+ * Utilizado no endpoint POST /api/auth/refresh para
+ * renovar access token usando refresh token válido. 
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshTokenRequest {
+    
+    /**
+     * Refresh token JWT recebido no login/registro
+     */
+    @NotBlank(message = "Refresh token é obrigatório")
+    private String refreshToken;
+}

--- a/backend/src/main/java/br/com/glprevenda/security/service/AuthService.java
+++ b/backend/src/main/java/br/com/glprevenda/security/service/AuthService.java
@@ -1,19 +1,23 @@
 package br.com.glprevenda.security.service;
 
+import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util. Set;
 import java.util.stream.Collectors;
 
 import org. springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework. security.authentication.UsernamePasswordAuthenticationToken;
 import org. springframework.security.core.Authentication;
 import org.springframework.security. core. GrantedAuthority;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import br.com.glprevenda.security.dto.AuthResponse;
 import br.com.glprevenda.security.dto. LoginRequest;
+import br.com.glprevenda. security.dto.RefreshTokenRequest;
 import br.com.glprevenda.security. dto.RegisterRequest;
 import br.com. glprevenda.security.dto.UserResponse;
 import br.com.glprevenda.security.entity. Role;
@@ -21,6 +25,8 @@ import br.com.glprevenda.security.entity. User;
 import br.com. glprevenda.security.repository.RoleRepository;
 import br.com.glprevenda. security.repository.UserRepository;
 import br.com.glprevenda. shared.exception.ResourceNotFoundException;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j. Slf4j;
 
@@ -191,5 +197,75 @@ public class AuthService {
                 .createdAt(user.getCreatedAt())
                 .updatedAt(user.getUpdatedAt())
                 .build();
+    }
+    
+    /**
+     * Renova tokens JWT usando Refresh Token
+     * 
+     * @param request DTO com refresh token
+     * @return Novos tokens (access + refresh)
+     * @throws BadCredentialsException se refresh token inválido
+     */
+    @Transactional(readOnly = true)
+    public AuthResponse refreshToken(RefreshTokenRequest request) {
+        log.info("Requisição de refresh token");
+        
+        try {
+            // 1. Extrair username do refresh token
+            String username = jwtService.extractUsername(request.getRefreshToken());
+            
+            if (username == null) {
+                log.error("Refresh token inválido:  username não encontrado");
+                throw new BadCredentialsException("Refresh token inválido");
+            }
+            
+            // 2. Buscar usuário no banco
+            User user = userRepository.findByUsername(username)
+                    .orElseThrow(() -> {
+                        log.error("Usuário não encontrado: {}", username);
+                        return new UsernameNotFoundException("Usuário não encontrado");
+                    });
+            
+            // 3. Verificar se usuário está ativo
+            if (!user.isEnabled()) {
+                log.error("Usuário inativo tentou renovar token:  {}", username);
+                throw new BadCredentialsException("Usuário inativo");
+            }
+            
+            // 4. Validar refresh token
+            if (!jwtService.isRefreshTokenValid(request.getRefreshToken(), user)) {
+                log.error("Refresh token inválido para usuário: {}", username);
+                throw new BadCredentialsException("Refresh token inválido ou expirado");
+            }
+            
+            // 5. Gerar novos tokens
+            String newAccessToken = jwtService. generateToken(user);
+            String newRefreshToken = jwtService.generateRefreshToken(user);
+            
+            log.info("Tokens renovados com sucesso para usuário: {}", username);
+            
+            // 6. Montar resposta
+            return AuthResponse. builder()
+                    .accessToken(newAccessToken)
+                    .refreshToken(newRefreshToken)
+                    .tokenType("Bearer")
+                    .expiresIn(jwtService.getJwtExpiration() / 1000)
+                    .userId(user.getId())
+                    .username(user.getUsername())
+                    .email(user. getEmail())
+                    .fullName(user.getFullName())
+                    .roles(user.getRoles().stream()
+                            .map(Role::getName)
+                            .collect(Collectors.toSet()))
+                    .issuedAt(LocalDateTime.now())
+                    .build();
+                    
+        } catch (ExpiredJwtException e) {
+            log.error("Refresh token expirado: {}", e.getMessage());
+            throw new BadCredentialsException("Refresh token expirado");
+        } catch (JwtException e) {
+            log.error("Erro ao processar refresh token: {}", e. getMessage());
+            throw new BadCredentialsException("Refresh token inválido");
+        }
     }
 }

--- a/backend/src/main/java/br/com/glprevenda/security/service/JwtService.java
+++ b/backend/src/main/java/br/com/glprevenda/security/service/JwtService.java
@@ -43,6 +43,33 @@ public class JwtService {
     private long refreshExpiration;
     
     /**
+     * Retorna o tempo de expiração do access token em milissegundos
+     * 
+     * @return Tempo em milissegundos
+     */
+    public long getJwtExpiration() {
+        return jwtExpiration;
+    }
+
+    /**
+     * Retorna o tempo de expiração do refresh token em milissegundos
+     * 
+     * @return Tempo em milissegundos
+     */
+    public long getRefreshExpiration() {
+        return refreshExpiration;
+    }
+
+    /**
+     * Retorna a secret key utilizada para assinar tokens
+     * 
+     * @return Secret key
+     */
+    public String getSecretKey() {
+        return secretKey;
+    }
+    
+    /**
      * Extrai o username do token JWT
      * 
      * @param token Token JWT
@@ -111,6 +138,45 @@ public class JwtService {
      * @param expiration Tempo de expiração
      * @return Token JWT
      */
+    
+    /**
+     * Valida se o token é um Refresh Token
+     * 
+     * @param token JWT a ser validado
+     * @return true se for refresh token válido
+     */
+    public boolean isRefreshToken(String token) {
+        try {
+            Claims claims = extractAllClaims(token);
+            // Refresh token NÃO tem roles
+            return ! claims.containsKey("roles");
+        } catch (Exception e) {
+            log.error("Erro ao verificar tipo de token: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Valida Refresh Token
+     * 
+     * @param token Refresh token
+     * @param userDetails Dados do usuário
+     * @return true se refresh token é válido
+     */
+    public boolean isRefreshTokenValid(String token, UserDetails userDetails) {
+        try {
+            final String username = extractUsername(token);
+            boolean isUsernameValid = username.equals(userDetails.getUsername());
+            boolean isTokenNotExpired = !isTokenExpired(token);
+            boolean isRefresh = isRefreshToken(token);
+            
+            return isUsernameValid && isTokenNotExpired && isRefresh;
+        } catch (Exception e) {
+            log.error("Erro ao validar refresh token: {}", e.getMessage());
+            return false;
+        }
+    }
+    
     private String buildToken(
             Map<String, Object> extraClaims,
             UserDetails userDetails,


### PR DESCRIPTION
- Criar RefreshTokenRequest DTO com validação Bean Validation
- Adicionar getters no JwtService (jwtExpiration, refreshExpiration)
- Implementar validação de refresh token (isRefreshToken, isRefreshTokenValid)
- Criar método AuthService.refreshToken() com validações completas
- Adicionar endpoint POST /api/auth/refresh no AuthController
- Documentar endpoint no Swagger/OpenAPI
- Implementar tratamento de erros de validação (400 Bad Request)
- Validar tipo de token (refresh vs access)
- Validar usuário ativo
- Validar token expirado/inválido
- Gerar novos access e refresh tokens
- Adicionar logs estruturados
- Tratamento de exceções (ExpiredJwtException, JwtException)

Testes realizados:
- ✅ Refresh com token válido (200 OK + novos tokens)
- ✅ Refresh com access token (401 Unauthorized)
- ✅ Refresh com token inválido (401 Unauthorized)
- ✅ Refresh com campo vazio (400 Bad Request)
- ✅ Novo access token funciona em endpoints protegidos

Resolves #3